### PR TITLE
Add get current tick method and route

### DIFF
--- a/include/core/mission_state.hpp
+++ b/include/core/mission_state.hpp
@@ -2,14 +2,15 @@
 #ifndef INCLUDE_CORE_MISSION_STATE_HPP_
 #define INCLUDE_CORE_MISSION_STATE_HPP_
 
-#include <memory>
 #include <chrono>
-#include <string> 
-#include <mutex> 
+#include <memory>
+#include <mutex>
+#include <string>
+
 #include "ticks/tick.hpp"
 
 class MissionState {
-public:
+ public:
     // Public state variables for ticks to interact with
     bool is_prepared = false;
     int task_progress = 0;
@@ -27,8 +28,11 @@ public:
     // Method for the OBC to set the very first tick
     void setInitialTick(Tick* first_tick);
 
-private:
+    // Method to get current tick ID
+    TickID getTickID();
+
+ private:
     Tick* current_tick;
 };
 
-#endif // INCLUDE_CORE_MISSION_STATE_HPP_
+#endif  // INCLUDE_CORE_MISSION_STATE_HPP_

--- a/include/network/gcs_routes.hpp
+++ b/include/network/gcs_routes.hpp
@@ -7,5 +7,6 @@
 #include "network/gcs_macros.hpp"
 
 DEF_GCS_HANDLE(Get, status);
+DEF_GCS_HANDLE(Get, tick);
 
 #endif // INCLUDE_NETWORK_GCS_ROUTES_HPP_

--- a/src/core/mission_state.cpp
+++ b/src/core/mission_state.cpp
@@ -1,4 +1,5 @@
 #include "core/mission_state.hpp"
+
 #include <iostream>
 
 MissionState::MissionState() : current_tick(nullptr) {
@@ -13,7 +14,6 @@ MissionState::~MissionState() {
         delete current_tick;
     }
 }
-
 
 void MissionState::setInitialTick(Tick* first_tick) {
     this->current_tick = first_tick;
@@ -50,4 +50,9 @@ std::chrono::milliseconds MissionState::doTick() {
     // If next_tick was nullptr, we do nothing and stay in the current state.
 
     return current_tick->getWait();
+}
+
+TickID MissionState::getTickID() {
+    std::lock_guard<std::mutex> lock(state_mut);
+    return current_tick->getID();
 }

--- a/src/network/gcs.cpp
+++ b/src/network/gcs.cpp
@@ -23,4 +23,5 @@ GCSServer::~GCSServer() {
 void GCSServer::_bindHandlers() {
     // Use our macro to bind the GET /status route
     BIND_HANDLER(Get, status);
+    BIND_HANDLER(Get, tick);
 }

--- a/src/network/gcs_routes.cpp
+++ b/src/network/gcs_routes.cpp
@@ -26,10 +26,10 @@ DEF_GCS_HANDLE(Get, status) {
     response.status = 200;
 }
 
-DEF_GCS_HANDLE(Get, tickstate) {
+DEF_GCS_HANDLE(Get, tick) {
     TickID tickID = state->getTickID();
     std::string tick_state = TICK_ID_TO_STR(tickID);
 
-    response.set_content(tick_state, mime::plaintext);
+    response.set_content(tick_state, "text/plain");
     response.status = 200;
 }

--- a/src/network/gcs_routes.cpp
+++ b/src/network/gcs_routes.cpp
@@ -15,7 +15,7 @@ DEF_GCS_HANDLE(Get, status) {
         status_proto.set_current_tick_name(state->current_tick_name);
         status_proto.set_is_connected(state->is_prepared);
         status_proto.set_mission_progress_percent(state->task_progress);
-    } 
+    }
 
     // Convert the Protobuf message to a JSON string
     std::string json_output;
@@ -23,5 +23,13 @@ DEF_GCS_HANDLE(Get, status) {
 
     // Set the HTTP response
     response.set_content(json_output, "application/json");
+    response.status = 200;
+}
+
+DEF_GCS_HANDLE(Get, tickstate) {
+    TickID tickID = state->getTickID();
+    std::string tick_state = TICK_ID_TO_STR(tickID);
+
+    response.set_content(tick_state, mime::plaintext);
     response.status = 200;
 }


### PR DESCRIPTION
Closes #8 

I added a method to get the current tick id and its associated route. Note that the method is to get the tick id, not the tick itself, as this is how we implemented it in our actual obc.

To test this, use the `feat/current_tick` branch on the gcs.